### PR TITLE
added config option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ If you have installed this package in global, you can run **c-preprocessor** and
 c-preprocessor mainFile.js outputFile.js
 ```
 
+Additionally you can specify config file (see below for it's format):
+```
+c-preprocessor --config configFile.js mainFile.js outputFile.js
+```
+
 #### With require()
 ```js
 var compiler = require("c-preprocessor");
@@ -72,7 +77,7 @@ var options = {
 	constants: {},
 
 	// Predefined macros (ex: { "MACRO": "(a,b) a+b" })
-	macro: {},
+	macros: {},
 
 	// End of line character
 	newLine: '\n',

--- a/examples/a file you can compile with config.js
+++ b/examples/a file you can compile with config.js
@@ -1,0 +1,26 @@
+/*
+
+This file works only when compiled with the config file (./configuration.json)
+
+
+Sources at https://github.com/ParksProjets/C-Preprocessor
+License GPLv2
+
+*/
+
+
+#include "included file.js"
+
+
+var x = SUM(MY_CONST, 8);
+
+#ifdef OK
+
+	if (x === 50) {
+		console.log('It works !');
+	}
+
+#endif
+
+
+console.log(x);

--- a/examples/configuration.json
+++ b/examples/configuration.json
@@ -1,0 +1,8 @@
+{
+	"constants": {
+		"MY_CONST": "42"
+	},
+	"macros": {
+		"SUM": "(a,b) a+b"
+	}
+}


### PR DESCRIPTION
This patch adds command line option (`-c`, `--config`), so the preprocessor can read configuration from file. It is very handy when you invoke it from command line, rather than from js.

Also, there is an example, so this option can be easily tested:
```bash
# compiles, but some of the macros aren't replaced
node ./bin/global.js "./examples/a file you can compile with config.js"

# compiles, and macroses are replaced with values from config file
node ./bin/global.js -c "./examples/configuration.json" "./examples/a file you can compile with config.js"

```

Since it is the only option at the moment, I decided not to pull additional dependencies like `commander`. Hope, that's OK for you!
