### PR TITLE
Fixups

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -712,7 +712,7 @@ createDirective("include", function(text) {
 
 			var e = '';
 			for (var i = 0, l = _this.options.includeSpaces; i < l; i++)
-				e += _this.options.endLine;
+				e += _this.options.newLine;
 
 			_this.addLine(e + processor.result.trim() + e);
 
@@ -747,12 +747,29 @@ createDirective("define", function(text) {
 	text = '';
 
 	while (str.last() == "\\") {
-		text += str.substr(0, str.length - 1) + this.options.endLine;
+		text += str.substr(0, str.length - 1) + this.options.newLine;
 		str = this.nextLine().trimRight();
 	}
 
 	text += str;
 
+	// Strip comments from the definition
+	var posBegin;
+	var posEnd;
+
+	while ((posBegin = text.indexOf('/*')) != -1) {
+		posEnd = text.indexOf('*/', 1 + posBegin);
+		if (posEnd == -1) {
+			posEnd = text.length;
+		}
+		text = text.substring(0, posBegin) + ' ' + text.substring(2 + posEnd);
+	}
+
+	if ((posBegin = text.indexOf('//')) != -1) {
+		text = text.substring(0, posBegin) + ' ';
+  }
+
+	text.trimRight();
 
 	// If there is an '(' after the name: define a macro
 	if (isMacro)
@@ -769,7 +786,7 @@ createDirective("define", function(text) {
 
 // #undef directive
 createDirective("undef", function(text) {
-	
+
 	// Get the constant/macro name
 	var i = 0;
 	while (text.isAlpha(i))

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -72,6 +72,9 @@ var Compiler = function(opt) {
 	// List of defined macros/constants
 	this.defines = {};
 
+	// Stack for macros/constants
+	this.stack = {};
+
 	// List of #pragma once
 	this.includeOnce = {};
 
@@ -714,6 +717,7 @@ createDirective("include", function(text) {
 			_this.addLine(e + processor.result.trim() + e);
 
 			_this.createConstant('__FILE__', _this.currentFile, false);
+
 			_this.next();
 		};
 
@@ -887,6 +891,47 @@ createDirective("pragma", function(text) {
 	// #pragma once: include a file once
 	if (text == 'once')
 		this.parent.includeOnce[this.currentFile] = true;
+
+	// #pragma push_macro(...): save current value of the specified macro on top
+	// of the stack
+	else if (text.startsWith('push_macro')) {
+
+		let match = text.match(/push_macro\("([^"]+)"\)/);
+    if (match === null || !match[1].length) {
+			this.error(`wrong pragma format`);
+		}
+		else {
+			let name = match[1];
+			if (this.parent.defines[name] === undefined) {
+				this.error(`macro ${name} is not defined, cannot push it`);
+			}
+			else {
+				if (this.parent.stack[name] === undefined) {
+					this.parent.stack[name] = [];
+				}
+				this.parent.stack[name].push(this.parent.defines[name]);
+			}
+		}
+	}
+
+	// #pragma pop_macro(...): set current value of the specified macro to
+	// previously saved value
+	else if (text.startsWith('pop_macro')) {
+
+		let match = text.match(/pop_macro\("([^"]+)"\)/);
+    if (match === null || !match[1].length) {
+			this.error(`wrong pragma format`);
+		}
+		else {
+			let name = match[1];
+			if (this.parent.stack[name] === undefined || !this.parent.stack[name].length) {
+				this.error(`stack for macro ${name} is empty, cannot pop from it`);
+			}
+			else {
+				this.parent.defines[name] = this.parent.stack[name].pop();
+			}
+		}
+	}
 
 	// Else: error
 	else

--- a/lib/src/compiler.js
+++ b/lib/src/compiler.js
@@ -36,6 +36,9 @@ var Compiler = function(opt) {
 	// List of defined macros/constants
 	this.defines = {};
 
+	// Stack for macros/constants
+	this.stack = {};
+
 	// List of #pragma once
 	this.includeOnce = {};
 

--- a/lib/src/directives/define.js
+++ b/lib/src/directives/define.js
@@ -30,12 +30,29 @@ createDirective("define", function(text) {
 	text = '';
 
 	while (str.last() == "\\") {
-		text += str.substr(0, str.length - 1) + this.options.endLine;
+		text += str.substr(0, str.length - 1) + this.options.newLine;
 		str = this.nextLine().trimRight();
 	}
 
 	text += str;
 
+	// Strip comments from the definition
+	var posBegin;
+	var posEnd;
+
+	while ((posBegin = text.indexOf('/*')) != -1) {
+		posEnd = text.indexOf('*/', 1 + posBegin);
+		if (posEnd == -1) {
+			posEnd = text.length;
+		}
+		text = text.substring(0, posBegin) + ' ' + text.substring(2 + posEnd);
+	}
+
+	if ((posBegin = text.indexOf('//')) != -1) {
+		text = text.substring(0, posBegin) + ' ';
+  }
+
+	text.trimRight();
 
 	// If there is an '(' after the name: define a macro
 	if (isMacro)
@@ -52,7 +69,7 @@ createDirective("define", function(text) {
 
 // #undef directive
 createDirective("undef", function(text) {
-	
+
 	// Get the constant/macro name
 	var i = 0;
 	while (text.isAlpha(i))

--- a/lib/src/directives/extra.js
+++ b/lib/src/directives/extra.js
@@ -20,6 +20,47 @@ createDirective("pragma", function(text) {
 	if (text == 'once')
 		this.parent.includeOnce[this.currentFile] = true;
 
+	// #pragma push_macro(...): save current value of the specified macro on top
+	// of the stack
+	else if (text.startsWith('push_macro')) {
+
+		let match = text.match(/push_macro\("([^"]+)"\)/);
+    if (match === null || !match[1].length) {
+			this.error(`wrong pragma format`);
+		}
+		else {
+			let name = match[1];
+			if (this.parent.defines[name] === undefined) {
+				this.error(`macro ${name} is not defined, cannot push it`);
+			}
+			else {
+				if (this.parent.stack[name] === undefined) {
+					this.parent.stack[name] = [];
+				}
+				this.parent.stack[name].push(this.parent.defines[name]);
+			}
+		}
+	}
+
+	// #pragma pop_macro(...): set current value of the specified macro to
+	// previously saved value
+	else if (text.startsWith('pop_macro')) {
+
+		let match = text.match(/pop_macro\("([^"]+)"\)/);
+    if (match === null || !match[1].length) {
+			this.error(`wrong pragma format`);
+		}
+		else {
+			let name = match[1];
+			if (this.parent.stack[name] === undefined || !this.parent.stack[name].length) {
+				this.error(`stack for macro ${name} is empty, cannot pop from it`);
+			}
+			else {
+				this.parent.defines[name] = this.parent.stack[name].pop();
+			}
+		}
+	}
+
 	// Else: error
 	else
 		this.error(`unknown pragma "${text}"`);

--- a/lib/src/directives/include.js
+++ b/lib/src/directives/include.js
@@ -47,7 +47,11 @@ createDirective("include", function(text) {
 
 			_this.addLine(e + processor.result.trim() + e);
 
+#pragma push_macro("__FILE__")
+#undef __FILE__
 			_this.createConstant('__FILE__', _this.currentFile, false);
+#pragma pop_macro("__FILE__")
+
 			_this.next();
 		};
 

--- a/lib/src/directives/include.js
+++ b/lib/src/directives/include.js
@@ -43,7 +43,7 @@ createDirective("include", function(text) {
 
 			var e = '';
 			for (var i = 0, l = _this.options.includeSpaces; i < l; i++)
-				e += _this.options.endLine;
+				e += _this.options.newLine;
 
 			_this.addLine(e + processor.result.trim() + e);
 

--- a/test/tests/define-macro.js
+++ b/test/tests/define-macro.js
@@ -26,6 +26,7 @@ var a = utils.randint(0, 100),
 test.result('r1', a * 5 * 7);
 test.result('r2', a*(b+12)*5*5 - 74);
 test.result('str', 'Name -> This is (a) label');
+test.result('f8', 21);
 
 
 // Predefined macros
@@ -45,9 +46,24 @@ test.run(`
 
 #define STR(name, label) name + " -> " + label
 
+#define MAT2(a,b,c,d) [a, b, c, d] // A 2x2 matrix
+
+#define MUL(m1,m2) [                 /* Multiplication of matrices */ \
+	(m1)[0]*(m2)[0] + (m1)[1]*(m2)[2], /* (0, 0)-element */             \
+	(m1)[0]*(m2)[1] + (m1)[2]*(m2)[3], /* (0, 1)-element */             \
+	(m1)[2]*(m2)[0] + (m1)[3]*(m2)[2], /* (1, 0)-element */             \
+	(m1)[2]*(m2)[1] + (m1)[3]*(m2)[3]] /* (1, 1)-element */
+
+
 var r1 = MACRO1(${a}, 7),
 	r2 = MACRO2(${a}, MACRO1(SUM(${b}, 12), 1), NUM);
 
 var str = STR('Name', 'This is (a) label')
+
+var m = MAT2(1,1,1,0);
+for (let i = 0; i < 3; ++i) {
+  m = MUL(m,m);
+}
+var f8 = m[1];
 
 `);


### PR DESCRIPTION
There are two fixups in this PR.

1) When you try to compile the sources, you get broken version of the compiler due to incorrect handling of macro [1]. (Here `__FILE__` wasn't supposed to be replaced with the filename.)
There are at least two way to fix it:
* ignore macros in strings
* temporarily undefine `__FILE__` [2]
I chose the latter one, since it's easier to implement and doesn't bring new questions (e.g. whether we should expand macros in template literals).
So in addition to the fixup there is also new functionality. I didn't document it, as it is pretty rare situation when the one might need it.

2) When you write comment at the end of a macro it becomes part of the macro, but that behaviour differs from what C99 specification says [3]. Consider the following example:
```c
#define SUCC(x) x+1 // next value

var y = SUCC(4) + 10;
```
Will be compiled to this:
```javascript
var y = 4+1 // next value + 10;
```
Which is not what the one might expect.
I fixed this behaviour and added test for it, so it's no more a problem.

[1] https://github.com/ParksProjets/C-Preprocessor/blob/master/lib/src/directives/include.js#L50
[2] https://stackoverflow.com/questions/1543736/how-do-i-temporarily-disable-a-macro-expansion-in-c-c#1545079
[3] https://stackoverflow.com/questions/1510869/does-the-c-preprocessor-strip-comments-or-expand-macros-first/1510919#1510919
