### PR TITLE
fix multi const in a line  bug

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -373,7 +373,7 @@ Compiler.prototype.addDefines = function(line, withConst, withMacros) {
 
 			line = r.line;
 			i1 = r.index;
-			break;
+			continue;
 		}
 	}
 
@@ -827,16 +827,13 @@ createDirective("undef", function(text) {
 // #if directive
 // See README to know how to use this directive
 createDirective("if", function(expr) {
-
 	// Exectute 'defined' function
 	var i, i2, name;
+	var _this = this;
 
-	while ( (i = expr.indexOf('defined(')) != -1 ) {
-		i2 = expr.indexOf(')', i);
-		name = expr.substring(i + 8, i2);
-		expr = expr.splice(i, i2 + 1 - i, this.defines[name] === undefined ? 'false' : 'true');
-	}
-
+	expr = expr.replace(/defined\s*\(\s*([\s\S]+?)\s*\)/g, function(match, p1){
+		return _this.defines[p1] === undefined ? 'false' : 'true';
+	});
 
 	// Replace constants by their values
 	expr = this.addDefines(expr);
@@ -941,8 +938,8 @@ createDirective("pragma", function(text) {
 	else if (text.startsWith('push_macro')) {
 
 		var match = text.match(/push_macro\("([^"]+)"\)/);
-    	
-    	if (match === null || match[1].length == 0)
+		
+		if (match === null || match[1].length == 0)
 			this.error(`wrong pragma format`);
 		else
 			this.pushMacro(match[1]);

--- a/lib/src/directives/condition.js
+++ b/lib/src/directives/condition.js
@@ -14,16 +14,13 @@ Sources at https://github.com/ParksProjets/C-Preprocessor
 // #if directive
 // See README to know how to use this directive
 createDirective("if", function(expr) {
-
 	// Exectute 'defined' function
 	var i, i2, name;
+	var _this = this;
 
-	while ( (i = expr.indexOf('defined(')) != -1 ) {
-		i2 = expr.indexOf(')', i);
-		name = expr.substring(i + 8, i2);
-		expr = expr.splice(i, i2 + 1 - i, this.defines[name] === undefined ? 'false' : 'true');
-	}
-
+	expr = expr.replace(/defined\s*\(\s*([\s\S]+?)\s*\)/g, function(match, p1){
+		return _this.defines[p1] === undefined ? 'false' : 'true';
+	});
 
 	// Replace constants by their values
 	expr = this.addDefines(expr);

--- a/lib/src/system/defines.js
+++ b/lib/src/system/defines.js
@@ -54,7 +54,7 @@ Compiler.prototype.addDefines = function(line, withConst, withMacros) {
 
 			line = r.line;
 			i1 = r.index;
-			break;
+			continue;
 		}
 	}
 


### PR DESCRIPTION
1. fix bug when a line has multi constants
   eg: 
    ```
      #define MATH_PI 3.1415926
      float a = MATH_PI * MATH_PI;
      ```
2. fix `#if defined (xxx)` bug